### PR TITLE
Add Windows-like audit desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # evaluacion1_auditoria
-evaluación numero 1 de auditoría de software
+
+Sitio interactivo para la asignatura **Auditoría de Software**. Simula un escritorio de estilo Windows inspirado en el mundo de Harry Potter. Cada ícono abre una ventana con distintos ejemplos de errores y malas prácticas de auditoría.
+
+Para probarlo localmente, abre `index.html` en tu navegador o utiliza un servidor simple de Python:
+
+```bash
+python3 -m http.server
+```
+
+Luego visita `http://localhost:8000`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ministerio OS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="desktop">
+        <div class="icon" data-window="dbWindow">
+            <span>Base de Datos</span>
+        </div>
+        <div class="icon" data-window="infraWindow">
+            <span>Mapa de Infraestructura</span>
+        </div>
+        <div class="icon" data-window="procWindow">
+            <span>Administrador de Procesos</span>
+        </div>
+        <div class="icon" data-window="licenseWindow">
+            <span>Licencia Texto</span>
+        </div>
+        <div class="icon" data-window="contaWindow">
+            <span>Contabilidad Mágica</span>
+        </div>
+        <div class="icon" data-window="mailWindow">
+            <span>Hedwig Mail</span>
+        </div>
+    </div>
+
+    <div id="dbWindow" class="window">
+        <div class="title-bar">Base de Datos de Alumnos<button class="close">X</button></div>
+        <pre id="dbData">{
+    "alumnos": [
+        {"nombre": "Harry Potter", "rut": "12345678-9", "direccion": "4 Privet Drive"},
+        {"nombre": "Hermione Granger", "rut": "98765432-1", "direccion": "Heathgate"}
+    ]
+}</pre>
+    </div>
+
+    <div id="infraWindow" class="window">
+        <div class="title-bar">Mapa de Infraestructura<button class="close">X</button></div>
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAgMCAfDwRqsAAAAASUVORK5CYII=" alt="Mapa de servidores" class="content-img">
+        <p>Nota: uno de los servidores está ubicado en el baño.</p>
+    </div>
+
+    <div id="procWindow" class="window">
+        <div class="title-bar">Administrador de Procesos<button class="close">X</button></div>
+        <ul>
+            <li>proceso.exe - Error</li>
+            <li>proceso.exe - Error (duplicado)</li>
+            <li>lognmanager - ???</li>
+        </ul>
+    </div>
+
+    <div id="licenseWindow" class="window">
+        <div class="title-bar">Licencia del Motor de Texto<button class="close">X</button></div>
+        <p>La licencia gratuita ha expirado. El software continúa en uso sin renovación.</p>
+    </div>
+
+    <div id="contaWindow" class="window">
+        <div class="title-bar">Contabilidad Mágica<button class="close">X</button></div>
+        <canvas id="chart1" width="200" height="150"></canvas>
+        <canvas id="chart2" width="200" height="150"></canvas>
+    </div>
+
+    <div id="mailWindow" class="window">
+        <div class="title-bar">Hedwig Mail<button class="close">X</button></div>
+        <ul>
+            <li>Correo 1: "Adjunto contrato sin cifrar..."</li>
+            <li>Correo 2: "Prácticas cuestionables..."</li>
+        </ul>
+    </div>
+
+    <div id="taskbar">
+        <span id="clock"></span>
+    </div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,58 @@
+function initWindows() {
+    document.querySelectorAll('.icon').forEach(icon => {
+        icon.addEventListener('click', () => {
+            const win = document.getElementById(icon.dataset.window);
+            if (win) win.style.display = 'block';
+        });
+    });
+    document.querySelectorAll('.close').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.target.closest('.window').style.display = 'none';
+        });
+    });
+    dragWindows();
+    updateClock();
+    setInterval(updateClock, 1000);
+    drawCharts();
+}
+
+function dragWindows() {
+    document.querySelectorAll('.window').forEach(win => {
+        const bar = win.querySelector('.title-bar');
+        let offsetX, offsetY, dragging = false;
+        bar.addEventListener('mousedown', (e) => {
+            dragging = true;
+            offsetX = e.clientX - win.offsetLeft;
+            offsetY = e.clientY - win.offsetTop;
+        });
+        document.addEventListener('mousemove', (e) => {
+            if (dragging) {
+                win.style.left = (e.clientX - offsetX) + 'px';
+                win.style.top = (e.clientY - offsetY) + 'px';
+            }
+        });
+        document.addEventListener('mouseup', () => dragging = false);
+    });
+}
+
+function updateClock() {
+    const now = new Date();
+    document.getElementById('clock').textContent = now.toLocaleTimeString();
+}
+
+function drawCharts() {
+    const ctx1 = document.getElementById('chart1').getContext('2d');
+    const ctx2 = document.getElementById('chart2').getContext('2d');
+    new Chart(ctx1, {
+        type: 'bar',
+        data: { labels: ['Ene', 'Feb'], datasets: [{ label: 'Sistema contable', data: [100, 200], backgroundColor: 'blue' }] },
+        options: { responsive: false }
+    });
+    new Chart(ctx2, {
+        type: 'bar',
+        data: { labels: ['Ene', 'Feb'], datasets: [{ label: 'Sistema principal', data: [90, 250], backgroundColor: 'green' }] },
+        options: { responsive: false }
+    });
+}
+
+window.onload = initWindows;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+body {
+    margin: 0;
+    font-family: sans-serif;
+    background: linear-gradient(#c0c0ff,#8080ff);
+    color: #000;
+}
+
+#desktop {
+    position: relative;
+    height: calc(100vh - 30px);
+    padding: 10px;
+}
+
+.icon {
+    width: 100px;
+    text-align: center;
+    cursor: pointer;
+    margin: 10px;
+    display: inline-block;
+}
+
+.icon-img {
+    width: 48px;
+    height: 48px;
+}
+
+.window {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    width: 300px;
+    background: #eee;
+    border: 2px solid #111;
+    display: none;
+}
+
+.title-bar {
+    background: #333;
+    color: #fff;
+    padding: 4px;
+    cursor: move;
+    display: flex;
+    justify-content: space-between;
+}
+
+.title-bar button {
+    background: red;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+#taskbar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 30px;
+    background: #222;
+    color: #fff;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0 10px;
+}


### PR DESCRIPTION
## Summary
- add interactive Harry Potter themed desktop
- add styles and behaviour for windows
- update README with usage instructions

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_685506e4a8e08326b221b4236f634ffe