### PR TITLE
Fix windows on load and improve interface

### DIFF
--- a/apps/conta.js
+++ b/apps/conta.js
@@ -1,6 +1,12 @@
 function drawCharts(){
     const ctx1 = document.getElementById('chart1').getContext('2d');
     const ctx2 = document.getElementById('chart2').getContext('2d');
-    new Chart(ctx1,{type:'bar',data:{labels:['Ene','Feb'],datasets:[{label:'Sistema oficial',data:[100,200],backgroundColor:'blue'}]},options:{responsive:false}});
-    new Chart(ctx2,{type:'bar',data:{labels:['Ene','Feb'],datasets:[{label:'Software interno',data:[80,250],backgroundColor:'green'}]},options:{responsive:false}});
+    const months=['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
+    const oficial=[100,200,150,170,190,210,180,205,230,240,260,300];
+    const interno=[80,250,120,200,220,190,200,215,225,220,230,240];
+    new Chart(ctx1,{type:'bar',data:{labels:months,datasets:[{label:'Sistema oficial',data:oficial,backgroundColor:'blue'}]},options:{responsive:false}});
+    new Chart(ctx2,{type:'bar',data:{labels:months,datasets:[{label:'Software interno',data:interno,backgroundColor:'green'}]},options:{responsive:false}});
+    const total1=oficial.reduce((a,b)=>a+b,0);
+    const total2=interno.reduce((a,b)=>a+b,0);
+    document.getElementById('totalConta').innerHTML=`<strong>Total oficial:</strong> ${total1} galleones<br><strong>Total interno:</strong> ${total2} galleones`;
 }

--- a/apps/db.js
+++ b/apps/db.js
@@ -17,18 +17,24 @@ function loadDB(){
             }
         }
 
+        const tree=document.createElement('ul');
+        tree.className='filetree';
+        nav.appendChild(tree);
+
         Object.keys(data).forEach(ds=>{
-            const dsDiv=document.createElement('div');
-            dsDiv.textContent=ds;
+            const dsLi=document.createElement('li');
+            dsLi.textContent=ds;
+            dsLi.classList.add('collapsed');
             const ul=document.createElement('ul');
             Object.keys(data[ds]).forEach(tb=>{
                 const li=document.createElement('li');
                 li.textContent=tb;
-                li.addEventListener('click',()=>render(ds,tb));
+                li.addEventListener('click',e=>{e.stopPropagation();render(ds,tb);});
                 ul.appendChild(li);
             });
-            dsDiv.appendChild(ul);
-            nav.appendChild(dsDiv);
+            dsLi.appendChild(ul);
+            dsLi.addEventListener('click',()=>dsLi.classList.toggle('collapsed'));
+            tree.appendChild(dsLi);
         });
 
         const firstDs=Object.keys(data)[0];

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Ministerio OS</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/magic-ui/dist/magic-ui.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -90,6 +91,7 @@
         <div class="window-content">
             <canvas id="chart1" width="200" height="150"></canvas>
             <canvas id="chart2" width="200" height="150"></canvas>
+            <div id="totalConta" class="mt-2"></div>
         </div>
     </div>
 
@@ -148,6 +150,7 @@
     <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/magic-ui/dist/magic-ui.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script src="apps/db.js"></script>
     <script src="apps/infra.js"></script>

--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ function createTaskItem(id){
 function openWindow(id){
     const win = document.getElementById(id);
     if(!win) return;
-    win.style.display = 'block';
+    win.style.display = 'flex';
     if(!win.dataset.opened){
         win.dataset.opened = '1';
         toggleMaximize(win);
@@ -206,8 +206,22 @@ function init(){
     if(enabledPrograms.includes('textWindow')) initEditor();
 }
 
+const defaultPrograms = [
+  { id: 'dbWindow', name: 'Base de Datos', icon: 'https://cdn-icons-png.flaticon.com/512/3075/3075977.png', enabled: true },
+  { id: 'infraWindow', name: 'Mapa de Infraestructura', icon: 'https://cdn-icons-png.flaticon.com/512/3474/3474369.png', enabled: true },
+  { id: 'procWindow', name: 'Administrador de Procesos', icon: 'https://cdn-icons-png.flaticon.com/512/865/865821.png', enabled: true },
+  { id: 'textWindow', name: 'Motor de Texto', icon: 'https://cdn-icons-png.flaticon.com/512/1027/1027219.png', enabled: true },
+  { id: 'contaWindow', name: 'Contabilidad', icon: 'https://cdn-icons-png.flaticon.com/512/1773/1773381.png', enabled: true },
+  { id: 'mailWindow', name: 'Hedwig Mail', icon: 'https://cdn-icons-png.flaticon.com/512/616/616490.png', enabled: true },
+  { id: 'monWindow', name: 'Monitoreo', icon: 'https://cdn-icons-png.flaticon.com/512/3103/3103493.png', enabled: true },
+  { id: 'orgWindow', name: 'Organigrama', icon: 'https://cdn-icons-png.flaticon.com/512/764/764460.png', enabled: true }
+];
+
 function loadPrograms(){
-    return fetch('programs.json').then(r=>r.json()).then(data=>{
+    return fetch('programs.json')
+        .then(r=>r.json())
+        .catch(()=>defaultPrograms)
+        .then(data=>{
         const desktop=document.getElementById('desktop');
         const menu=document.querySelector('#startMenu ul');
         data.forEach(p=>{

--- a/style.css
+++ b/style.css
@@ -49,7 +49,6 @@ body {
     display: none;
     box-shadow: 3px 3px 8px rgba(0,0,0,0.5);
     overflow: hidden;
-    display: flex;
     flex-direction: column;
 }
 
@@ -182,6 +181,20 @@ body {
 
 #mailView h5 {
     margin-top: 0;
+}
+
+.filetree,
+.filetree ul {
+    list-style: none;
+    padding-left: 1rem;
+}
+
+.filetree li {
+    cursor: pointer;
+}
+
+.filetree li.collapsed > ul {
+    display: none;
 }
 
 #taskbar {


### PR DESCRIPTION
## Summary
- hide windows until user interaction
- add fallback program list so icons always appear
- add Magic UI assets
- show accounting totals and expanded chart data
- display database navigation with a file tree

## Testing
- `node --check apps/conta.js`
- `node --check apps/db.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68562b2eed84832691064b78d41164bb