### PR TITLE
Improve text editor UI and database window

### DIFF
--- a/apps/db.js
+++ b/apps/db.js
@@ -23,12 +23,12 @@ function loadDB(){
 
         Object.keys(data).forEach(ds=>{
             const dsLi=document.createElement('li');
-            dsLi.textContent=ds;
+            dsLi.innerHTML=`<i class="fa-solid fa-database"></i> <span>${ds}</span>`;
             dsLi.classList.add('collapsed');
             const ul=document.createElement('ul');
             Object.keys(data[ds]).forEach(tb=>{
                 const li=document.createElement('li');
-                li.textContent=tb;
+                li.innerHTML=`<i class="fa-solid fa-table"></i> <span>${tb}</span>`;
                 li.addEventListener('click',e=>{e.stopPropagation();render(ds,tb);});
                 ul.appendChild(li);
             });

--- a/apps/editor.js
+++ b/apps/editor.js
@@ -1,5 +1,16 @@
 function initEditor(){
-    document.getElementById('newDoc').addEventListener('click',()=>{document.getElementById('editor').value='';});
-    document.getElementById('openDoc').addEventListener('click',()=>{document.getElementById('editor').value='Contenido de ejemplo';});
+    const editor = document.getElementById('editor');
+    document.getElementById('newDoc').addEventListener('click',()=>{editor.innerHTML='';});
+    document.getElementById('openDoc').addEventListener('click',()=>{editor.innerHTML='<p>Contenido de ejemplo</p>';});
     document.getElementById('saveDoc').addEventListener('click',()=>alert('Documento guardado (simulado)'));
+    document.getElementById('copyBtn').addEventListener('click',()=>document.execCommand('copy'));
+    document.getElementById('pasteBtn').addEventListener('click',()=>document.execCommand('paste'));
+    document.getElementById('boldBtn').addEventListener('click',()=>document.execCommand('bold'));
+    document.getElementById('italicBtn').addEventListener('click',()=>document.execCommand('italic'));
+    document.getElementById('underlineBtn').addEventListener('click',()=>document.execCommand('underline'));
+    document.getElementById('alignLeftBtn').addEventListener('click',()=>document.execCommand('justifyLeft'));
+    document.getElementById('alignCenterBtn').addEventListener('click',()=>document.execCommand('justifyCenter'));
+    document.getElementById('alignRightBtn').addEventListener('click',()=>document.execCommand('justifyRight'));
+    document.getElementById('bulletsBtn').addEventListener('click',()=>document.execCommand('insertUnorderedList'));
+    document.getElementById('numberedBtn').addEventListener('click',()=>document.execCommand('insertOrderedList'));
 }

--- a/data.json
+++ b/data.json
@@ -830,5 +830,15 @@
         "fecha": "2023-06-20"
       }
     ]
+  },
+  "Quidditch": {
+    "Equipos": [
+      {"nombre": "Chudley Cannons", "region": "Reino Unido"},
+      {"nombre": "Puddlemere United", "region": "Reino Unido"}
+    ],
+    "Jugadores": [
+      {"nombre": "Oliver Wood", "equipo": "Puddlemere United"},
+      {"nombre": "Viktor Krum", "equipo": "Bulgaria"}
+    ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Ministerio OS</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/magic-ui/dist/magic-ui.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,9 +15,9 @@
     <div id="dbWindow" class="window mui-window">
         <div class="title-bar"><span>Base de Datos</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content db">
@@ -24,16 +25,15 @@
             <div class="db-table-container">
                 <table id="dbTable" class="mui-table"></table>
             </div>
-            <p class="notice">Este es un entorno de pruebas. Algunos datos pueden no ser reales.</p>
         </div>
     </div>
 
     <div id="infraWindow" class="window mui-window">
         <div class="title-bar"><span>Mapa de Infraestructura</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content">
@@ -45,9 +45,9 @@
     <div id="procWindow" class="window mui-window">
         <div class="title-bar"><span>Administrador de Procesos</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content">
@@ -58,23 +58,28 @@
     <div id="textWindow" class="window mui-window">
         <div class="title-bar"><span>Motor de Texto</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content">
             <div class="toolbar">
-                <button id="newDoc" class="mui-btn">Nuevo</button>
-                <button id="openDoc" class="mui-btn">Abrir</button>
-                <button id="saveDoc" class="mui-btn">Guardar</button>
-                <button class="mui-btn">Copiar</button>
-                <button class="mui-btn">Pegar</button>
-                <button class="mui-btn">Negrita</button>
-                <button class="mui-btn">Cursiva</button>
-                <button class="mui-btn">Subrayado</button>
+                <button id="newDoc" class="mui-btn"><i class="fa-solid fa-file"></i></button>
+                <button id="openDoc" class="mui-btn"><i class="fa-solid fa-folder-open"></i></button>
+                <button id="saveDoc" class="mui-btn"><i class="fa-solid fa-floppy-disk"></i></button>
+                <button id="copyBtn" class="mui-btn"><i class="fa-solid fa-copy"></i></button>
+                <button id="pasteBtn" class="mui-btn"><i class="fa-solid fa-paste"></i></button>
+                <button id="boldBtn" class="mui-btn"><i class="fa-solid fa-bold"></i></button>
+                <button id="italicBtn" class="mui-btn"><i class="fa-solid fa-italic"></i></button>
+                <button id="underlineBtn" class="mui-btn"><i class="fa-solid fa-underline"></i></button>
+                <button id="alignLeftBtn" class="mui-btn"><i class="fa-solid fa-align-left"></i></button>
+                <button id="alignCenterBtn" class="mui-btn"><i class="fa-solid fa-align-center"></i></button>
+                <button id="alignRightBtn" class="mui-btn"><i class="fa-solid fa-align-right"></i></button>
+                <button id="bulletsBtn" class="mui-btn"><i class="fa-solid fa-list-ul"></i></button>
+                <button id="numberedBtn" class="mui-btn"><i class="fa-solid fa-list-ol"></i></button>
             </div>
-            <textarea id="editor" rows="10"></textarea>
+            <div id="editor" contenteditable="true" class="mui-mt-2 editor-area"></div>
             <div id="licenseMsg" class="license-msg">Licencia vencida</div>
         </div>
     </div>
@@ -82,9 +87,9 @@
     <div id="contaWindow" class="window mui-window">
         <div class="title-bar"><span>Contabilidad</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content">
@@ -97,24 +102,23 @@
     <div id="mailWindow" class="window mui-window">
         <div class="title-bar"><span>Hedwig Mail</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content mail">
             <div id="mailList" class="mui-list"></div>
             <div id="mailView" class="mail-view"></div>
-            <p class="notice">Este es un sistema de prueba, algunos datos pueden no ser reales.</p>
         </div>
     </div>
 
     <div id="monWindow" class="window mui-window">
         <div class="title-bar"><span>Monitoreo</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content">
@@ -125,9 +129,9 @@
     <div id="orgWindow" class="window mui-window">
         <div class="title-bar"><span>Organigrama</span>
             <div class="window-buttons">
-                <button class="minimize mui-btn">_</button>
-                <button class="maximize mui-btn"></button>
-                <button class="close mui-btn">X</button>
+                <button class="minimize mui-btn" aria-label="Minimizar"></button>
+                <button class="maximize mui-btn" aria-label="Maximizar"></button>
+                <button class="close mui-btn" aria-label="Cerrar"></button>
             </div>
         </div>
         <div class="window-content">

--- a/style.css
+++ b/style.css
@@ -9,6 +9,11 @@ body {
     position: relative;
     height: calc(100vh - 32px);
     padding: 10px;
+    background-image: linear-gradient(45deg, rgba(255,0,150,0.2) 25%, transparent 25%),
+                      linear-gradient(-45deg, rgba(0,200,255,0.2) 25%, transparent 25%),
+                      linear-gradient(45deg, transparent 75%, rgba(0,200,255,0.2) 75%),
+                      linear-gradient(-45deg, transparent 75%, rgba(255,0,150,0.2) 75%);
+    background-size: 20px 20px;
 }
 
 .icon {
@@ -86,39 +91,56 @@ body {
     align-items: center;
 }
 .window-buttons button {
-    background: #888;
-    color: #fff;
     border: none;
-    width: 20px;
-    height: 20px;
-    margin-left: 2px;
-    cursor: pointer;
-    border-radius: 4px;
+    width: 14px;
+    height: 14px;
+    margin-left: 4px;
+    border-radius: 50%;
     padding: 0;
+    cursor: pointer;
 }
-.window-buttons .maximize::after {
-    content: '\2610';
-    font-size: 14px;
-}
-.window-buttons .minimize::after { content: '-'; }
-.window-buttons .close::after { content: '\00d7'; }
+.window-buttons .close { background: #ff5f57; }
+.window-buttons .minimize { background: #ffbd2e; }
+.window-buttons .maximize { background: #28c840; }
+.window-buttons button::after { content: ''; }
 
 .window-content {
     padding: 8px;
     background: #fff;
     flex: 1;
+    position: relative;
     overflow-y: auto;
     overflow-x: hidden;
 }
 
+.toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 4px;
+}
 .toolbar button {
     margin-right: 4px;
+    min-width: 28px;
+}
+
+#textWindow .window-content {
+    display: flex;
+    flex-direction: column;
+}
+
+.editor-area {
+    flex: 1;
+    min-height: 0;
+    border: 1px solid #ccc;
+    padding: 4px;
+    overflow-y: auto;
 }
 
 .license-msg {
     position: absolute;
     bottom: 4px;
-    left: 4px;
+    right: 4px;
     background: #ffc107;
     color: #000;
     padding: 2px 6px;
@@ -165,6 +187,7 @@ body {
     border-right: 1px solid #ccc;
     padding-right: 4px;
     overflow-y: auto;
+    border-radius: 6px;
 }
 .db-nav ul {
     list-style: none;
@@ -191,6 +214,16 @@ body {
 
 .filetree li {
     cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.filetree li:hover {
+    background: #eef;
+}
+
+.filetree li i {
+    margin-right: 4px;
 }
 
 .filetree li.collapsed > ul {
@@ -264,6 +297,7 @@ body {
 .mui-btn:hover {
     background: #4500b5;
 }
+
 
 .mui-table {
     width: 100%;


### PR DESCRIPTION
## Summary
- use FontAwesome icons for the text editor toolbar
- center toolbar buttons and expand editor to fill window
- adopt mac-style window buttons and colorful grid desktop background
- add icons for database tree and include new Quidditch dataset
- remove demo disclaimers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68562f6020488326af4555b312bafb8f