### PR TITLE
Improve diagram and editor windows

### DIFF
--- a/apps/editor.js
+++ b/apps/editor.js
@@ -1,5 +1,6 @@
 function initEditor(){
     const editor = document.getElementById('editor');
+    editor.innerHTML = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>';
     document.getElementById('newDoc').addEventListener('click',()=>{editor.innerHTML='';});
     document.getElementById('openDoc').addEventListener('click',()=>{editor.innerHTML='<p>Contenido de ejemplo</p>';});
     document.getElementById('saveDoc').addEventListener('click',()=>alert('Documento guardado (simulado)'));

--- a/apps/infra.js
+++ b/apps/infra.js
@@ -46,6 +46,8 @@ function loadInfra(){
             p5h1 --> p5srv(Servidor Principal);
             p5h2 --> p5sw(Switch Backup);
         end`;
-    document.getElementById('infraDiagram').innerHTML=`<pre class="mermaid">${diagram}</pre>`;
+    const container=document.getElementById('infraDiagram');
+    container.innerHTML=`<pre class="mermaid">${diagram}</pre>`;
     if(window.mermaid){mermaid.init(undefined, '#infraDiagram .mermaid');}
+    if(window.enablePanning) enablePanning(container);
 }

--- a/apps/org.js
+++ b/apps/org.js
@@ -56,6 +56,8 @@ function loadOrgChart(){
         HeadADM-->ADM9["Kreacher\nServicios"];
         HeadADM-->ADM10["Winky\nAsistente"];
     `;
-    document.getElementById('orgChart').innerHTML=`<pre class="mermaid">${chart}</pre>`;
+    const container=document.getElementById('orgChart');
+    container.innerHTML=`<pre class="mermaid">${chart}</pre>`;
     if(window.mermaid){mermaid.init(undefined, '#orgChart .mermaid');}
+    if(window.enablePanning) enablePanning(container);
 }

--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
         </div>
         <div class="window-content">
             <div id="infraDiagram"></div>
-            <p class="notice">Servidor ubicado erróneamente en el baño.</p>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -177,7 +177,28 @@ function dragIcons(){
                 icon.style.top=(e.clientY-offsetY)+'px';
             }
         });
-        document.addEventListener('mouseup', ()=>dragging=false);
+    document.addEventListener('mouseup', ()=>dragging=false);
+    });
+}
+
+function enablePanning(el){
+    let isDown=false,startX,startY,scrollLeft,scrollTop;
+    el.addEventListener('mousedown',e=>{
+        isDown=true;
+        el.classList.add('panning');
+        startX=e.clientX;
+        startY=e.clientY;
+        scrollLeft=el.scrollLeft;
+        scrollTop=el.scrollTop;
+    });
+    document.addEventListener('mousemove',e=>{
+        if(!isDown) return;
+        el.scrollLeft=scrollLeft-(e.clientX-startX);
+        el.scrollTop=scrollTop-(e.clientY-startY);
+    });
+    document.addEventListener('mouseup',()=>{
+        isDown=false;
+        el.classList.remove('panning');
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -121,10 +121,10 @@ body {
 }
 .editor-area {
     border: 1px solid #ccc;
-    min-height: 200px;
     padding: 4px;
     width: 100%;
     overflow-y: auto;
+    flex: 1;
 }
 .toolbar button {
     margin-right: 4px;
@@ -323,4 +323,29 @@ body {
 
 .mui-mt-2 {
     margin-top: 0.5rem;
+}
+
+/* custom layouts */
+#textWindow .window-content {
+    display: flex;
+    flex-direction: column;
+}
+
+#infraWindow .window-content,
+#orgWindow .window-content {
+    padding: 0;
+    overflow: hidden;
+}
+
+#infraDiagram,
+#orgChart {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    cursor: grab;
+}
+
+#infraDiagram.panning,
+#orgChart.panning {
+    cursor: grabbing;
 }


### PR DESCRIPTION
## Summary
- remove stray infrastructure server notice
- add default lorem ipsum text in the editor
- allow panning for diagrams
- expand diagrams and editor to fill window space

## Testing
- `node -e "require('fs').readFileSync('script.js');"`
- `for f in apps/*.js script.js; do node -e "require('fs').readFileSync('$f');" && echo "$f ok"; done`


------
https://chatgpt.com/codex/tasks/task_e_68563cf2fe708326ab273a7989b7de66