### PR TITLE
Fix org chart binding and use Potter data

### DIFF
--- a/apps/org.js
+++ b/apps/org.js
@@ -59,9 +59,9 @@ function loadOrgChart() {
     shape.fill = theme.colors.personNodeBackground;
     shape.strokeWidth = STROKE_WIDTH;
     shape.bind('stroke', statusProperty, s => getStrokeForStatus(s));
-    shape.bindObject('stroke', 'isHighlighted', (isH, obj) =>
+    shape.bind('stroke', 'isHighlighted', (isH, obj) =>
       isH ? theme.colors.selectionStroke : getStrokeForStatus(obj.part.data.status)
-    );
+    ).ofObject();
     return shape;
   }
 
@@ -226,7 +226,7 @@ function loadOrgChart() {
   diagram.model.addNodeDataCollection(familyData);
 
   diagram.addDiagramListener('InitialLayoutCompleted', () => {
-    const root = diagram.findNodeForKey('King George V');
+    const root = diagram.findNodeForKey('Albus Dumbledore');
     if (!root) return;
     diagram.scale = 0.6;
     diagram.scrollToRect(root.actualBounds);
@@ -234,100 +234,25 @@ function loadOrgChart() {
 }
 
 const familyData = [
-  { name: 'King George V', gender: 'M', status: 'king', born: '1865', death: '1936' },
-  { name: 'King Edward VIII', gender: 'M', status: 'king', born: '1894', death: '1972', parent: 'King George V' },
-  { name: 'King George VI', gender: 'M', status: 'king', born: '1895', death: '1952', parent: 'King George V' },
-  { name: 'Princess Mary, Princess Royal and Countess of Harewood', gender: 'F', status: 'princess', born: '1897', death: '1965', parent: 'King George V' },
-  { name: 'Prince Henry, Duke of Gloucester', gender: 'M', status: 'prince', born: '1900', death: '1974', parent: 'King George V' },
-  { name: 'Prince George, Duke of Kent', gender: 'M', status: 'prince', born: '1902', death: '1942', parent: 'King George V' },
-  { name: 'Prince John of the United Kingdom', gender: 'M', status: 'prince', born: '1905', death: '1919', parent: 'King George V' },
-  { name: 'Queen Elizabeth II', gender: 'F', status: 'queen', born: '1926', death: '2022', parent: 'King George VI' },
-  { name: 'Princess Margaret, Countess of Snowdon', gender: 'F', status: 'princess', born: '1930', death: '2002', parent: 'King George VI' },
-  { name: 'George Lascelles', gender: 'M', status: 'civilian', born: '1923', death: '2011', parent: 'Princess Mary, Princess Royal and Countess of Harewood' },
-  { name: 'Gerald Lascelles', gender: 'M', status: 'civilian', born: '1924', death: '1998', parent: 'Princess Mary, Princess Royal and Countess of Harewood' },
-  { name: 'Prince William of Gloucester', gender: 'M', status: 'prince', born: '1941', death: '1972', parent: 'Prince Henry, Duke of Gloucester' },
-  { name: 'Prince Richard, Duke of Gloucester', gender: 'M', status: 'prince', born: '1944', death: null, parent: 'Prince Henry, Duke of Gloucester' },
-  { name: 'Prince Edward, Duke of Kent', gender: 'M', status: 'prince', born: '1935', death: null, parent: 'Prince George, Duke of Kent' },
-  { name: 'Princess Alexandra, The Honourable Lady Ogilvy', gender: 'F', status: 'princess', born: '1936', death: null, parent: 'Prince George, Duke of Kent' },
-  { name: 'Prince Michael of Kent', gender: 'M', status: 'prince', born: '1942', death: null, parent: 'Prince George, Duke of Kent' },
-  { name: 'King Charles III', gender: 'M', status: 'king', born: '1948', death: null, parent: 'Queen Elizabeth II' },
-  { name: 'Princess Anne, Princess Royal', gender: 'F', status: 'princess', born: '1950', death: null, parent: 'Queen Elizabeth II' },
-  { name: 'Prince Andrew, Duke of York', gender: 'M', status: 'prince', born: '1960', death: null, parent: 'Queen Elizabeth II' },
-  { name: 'Prince Edward, Duke of Edinburgh', gender: 'M', status: 'prince', born: '1964', death: null, parent: 'Queen Elizabeth II' },
-  { name: 'David Armstrong-Jones, 2nd Earl of Snowdon', gender: 'M', status: 'prince', born: '1961', death: null, parent: 'Princess Margaret, Countess of Snowdon' },
-  { name: 'Lady Sarah Chatto Armstrong-Jones', gender: 'F', status: 'princess', born: '1964', death: null, parent: 'Princess Margaret, Countess of Snowdon' },
-  { name: 'David Lascelles', gender: 'M', status: 'civilian', born: '1950', death: null, parent: 'George Lascelles' },
-  { name: 'James Lascelles', gender: 'M', status: 'civilian', born: '1953', death: null, parent: 'George Lascelles' },
-  { name: 'Jeremy Lascelles', gender: 'M', status: 'civilian', born: '1955', death: null, parent: 'George Lascelles' },
-  { name: 'Mark Lascelles', gender: 'M', status: 'civilian', born: '1964', death: null, parent: 'George Lascelles' },
-  { name: 'Martin David Lascelles', gender: 'M', status: 'civilian', born: '1962', death: null, parent: 'Gerald Lascelles' },
-  { name: 'Henry Lascelles', gender: 'M', status: 'civilian', born: '1953', death: null, parent: 'Gerald Lascelles' },
-  { name: 'Alexander Windsor, Earl of Ulster', gender: 'M', status: 'civilian', born: '1974', death: null, parent: 'Prince Richard, Duke of Gloucester' },
-  { name: 'Lady Davina Lewis', gender: 'F', status: 'civilian', born: '1977', death: null, parent: 'Prince Richard, Duke of Gloucester' },
-  { name: 'Lady Rose Gilman', gender: 'F', status: 'civilian', born: '1980', death: null, parent: 'Prince Richard, Duke of Gloucester' },
-  { name: 'George Windsor', gender: 'M', status: 'civilian', born: '1962', death: null, parent: 'Prince Edward, Duke of Kent' },
-  { name: 'Lady Helen Taylor', gender: 'F', status: 'civilian', born: '1964', death: null, parent: 'Prince Edward, Duke of Kent' },
-  { name: 'Lord Nicholas Windsor', gender: 'M', status: 'civilian', born: '1970', death: null, parent: 'Prince Edward, Duke of Kent' },
-  { name: 'James Ogilvy', gender: 'M', status: 'civilian', born: '1964', death: null, parent: 'Princess Alexandra, The Honourable Lady Ogilvy' },
-  { name: 'Marina Ogilvy', gender: 'F', status: 'civilian', born: '1966', death: null, parent: 'Princess Alexandra, The Honourable Lady Ogilvy' },
-  { name: 'Lord Frederick Windsor', gender: 'M', status: 'civilian', born: '1979', death: null, parent: 'Prince Michael of Kent' },
-  { name: 'Lady Gabriella Windsor', gender: 'F', status: 'civilian', born: '1981', death: null, parent: 'Prince Michael of Kent' },
-  { name: 'Prince William, Prince of Wales', gender: 'M', status: 'prince', born: '1982', death: null, parent: 'King Charles III' },
-  { name: 'Prince Harry, Duke of Sussex', gender: 'M', status: 'prince', born: '1984', death: null, parent: 'King Charles III' },
-  { name: 'Peter Phillips', gender: 'M', status: 'civilian', born: '1977', death: null, parent: 'Princess Anne, Princess Royal' },
-  { name: 'Zara Phillips', gender: 'F', status: 'civilian', born: '1981', death: null, parent: 'Princess Anne, Princess Royal' },
-  { name: 'Princess Beatrice of York', gender: 'F', status: 'princess', born: '1988', death: null, parent: 'Prince Andrew, Duke of York' },
-  { name: 'Princess Eugenie of York', gender: 'F', status: 'princess', born: '1990', death: null, parent: 'Prince Andrew, Duke of York' },
-  { name: 'Lady Louise Windsor', gender: 'F', status: 'civilian', born: '2003', death: null, parent: 'Prince Edward, Duke of Edinburgh' },
-  { name: 'James Viscount Severn, Earl of Wessex', gender: 'M', status: 'prince', born: '2007', death: null, parent: 'Prince Edward, Duke of Edinburgh' },
-  { name: 'Samuel Chatto', gender: 'M', status: 'civilian', born: '1996', death: null, parent: 'Lady Sarah Chatto Armstrong-Jones' },
-  { name: 'Arthur Chatto', gender: 'M', status: 'civilian', born: '1999', death: null, parent: 'Lady Sarah Chatto Armstrong-Jones' },
-  { name: 'Emily Shard', gender: 'F', status: 'civilian', born: '1975', death: null, parent: 'David Lascelles' },
-  { name: 'Benjamin Lascelles', gender: 'M', status: 'civilian', born: '1978', death: null, parent: 'David Lascelles' },
-  { name: 'Alexander Lascelles', gender: 'M', status: 'civilian', born: '1980', death: null, parent: 'David Lascelles' },
-  { name: 'Edward Lascelles', gender: 'M', status: 'civilian', born: '1982', death: null, parent: 'David Lascelles' },
-  { name: 'Tanit Lascelles', gender: 'F', status: 'civilian', born: '1981', death: null, parent: 'James Lascelles' },
-  { name: 'Tewa Lascelles', gender: 'M', status: 'civilian', born: '1985', death: null, parent: 'James Lascelles' },
-  { name: 'Sophie Lascelles', gender: 'F', status: 'civilian', born: '1973', death: null, parent: 'James Lascelles' },
-  { name: 'Rowan Lascelles', gender: 'M', status: 'civilian', born: '1977', death: null, parent: 'James Lascelles' },
-  { name: 'Tallulah Lascelles', gender: 'F', status: 'civilian', born: '2005', death: null, parent: 'Jeremy Lascelles' },
-  { name: 'Thomas Lascelles', gender: 'M', status: 'civilian', born: '1982', death: null, parent: 'Jeremy Lascelles' },
-  { name: 'Ellen Lascelles', gender: 'F', status: 'civilian', born: '1984', death: null, parent: 'Jeremy Lascelles' },
-  { name: 'Amy Lascelles', gender: 'F', status: 'civilian', born: '1986', death: null, parent: 'Jeremy Lascelles' },
-  { name: 'Charlotte Lascelles', gender: 'F', status: 'civilian', born: '1996', death: null, parent: 'Mark Lascelles' },
-  { name: 'Imogen Lascelles', gender: 'F', status: 'civilian', born: '1998', death: null, parent: 'Mark Lascelles' },
-  { name: 'Miranda Lascelles', gender: 'F', status: 'civilian', born: '2000', death: null, parent: 'Mark Lascelles' },
-  { name: 'Alexandre Joshua Lascelles', gender: 'M', status: 'civilian', born: '1996', death: null, parent: 'Martin David Lascelles' },
-  { name: 'Maximillian David Lascelles', gender: 'M', status: 'civilian', born: '1991', death: null, parent: 'Henry Lascelles' },
-  { name: 'Xan Windsor', gender: 'M', status: 'civilian', born: '2007', death: null, parent: 'Alexander Windsor, Earl of Ulster' },
-  { name: 'Lady Cosima Windsor', gender: 'F', status: 'civilian', born: '2010', death: null, parent: 'Alexander Windsor, Earl of Ulster' },
-  { name: 'Senna Lewis', gender: 'F', status: 'civilian', born: '2010', death: null, parent: 'Lady Davina Lewis' },
-  { name: 'Lyla Gilman', gender: 'F', status: 'civilian', born: '2010', death: null, parent: 'Lady Rose Gilman' },
-  { name: 'Edward Windsor', gender: 'M', status: 'civilian', born: '1988', death: null, parent: 'George Windsor' },
-  { name: 'Lady Marina-Charlotte Windsor', gender: 'F', status: 'civilian', born: '1992', death: null, parent: 'George Windsor' },
-  { name: 'Lady Amelia Windsor', gender: 'F', status: 'civilian', born: '1995', death: null, parent: 'George Windsor' },
-  { name: 'Columbus Taylor', gender: 'M', status: 'civilian', born: '1994', death: null, parent: 'Lady Helen Taylor' },
-  { name: 'Cassius Taylor', gender: 'M', status: 'civilian', born: '1996', death: null, parent: 'Lady Helen Taylor' },
-  { name: 'Eloise Taylor', gender: 'F', status: 'civilian', born: '2003', death: null, parent: 'Lady Helen Taylor' },
-  { name: 'Estella Taylor', gender: 'F', status: 'civilian', born: '2004', death: null, parent: 'Lady Helen Taylor' },
-  { name: 'Albert Windsor', gender: 'M', status: 'civilian', born: '2007', death: null, parent: 'Lord Nicholas Windsor' },
-  { name: 'Leopold Windsor', gender: 'M', status: 'civilian', born: '2009', death: null, parent: 'Lord Nicholas Windsor' },
-  { name: 'Flora Ogilvy', gender: 'F', status: 'civilian', born: '1994', death: null, parent: 'James Ogilvy' },
-  { name: 'Alexander Ogilvy', gender: 'M', status: 'civilian', born: '1996', death: null, parent: 'James Ogilvy' },
-  { name: 'Zenouska Mowatt', gender: 'F', status: 'civilian', born: '1990', death: null, parent: 'Marina Ogilvy' },
-  { name: 'Christian Mowatt', gender: 'M', status: 'civilian', born: '1993', death: null, parent: 'Marina Ogilvy' },
-  { name: 'Prince George of Wales', gender: 'M', status: 'prince', born: '2013', death: null, parent: 'Prince William, Prince of Wales' },
-  { name: 'Princess Charlotte of Wales', gender: 'F', status: 'princess', born: '2015', death: null, parent: 'Prince William, Prince of Wales' },
-  { name: 'Prince Louis of Wales', gender: 'M', status: 'prince', born: '2018', death: null, parent: 'Prince William, Prince of Wales' },
-  { name: 'Prince Archie of Sussex', gender: 'M', status: 'prince', born: '2019', death: null, parent: 'Prince Harry, Duke of Sussex' },
-  { name: 'Princess Lilibet of Sussex', gender: 'F', status: 'princess', born: '2021', death: null, parent: 'Prince Harry, Duke of Sussex' },
-  { name: 'Savannah Anne Kathleen Phillips', gender: 'F', status: 'civilian', born: '2010', death: null, parent: 'Peter Phillips' },
-  { name: 'Isla Elizabeth Phillips', gender: 'F', status: 'civilian', born: '2012', death: null, parent: 'Peter Phillips' },
-  { name: 'Mia Grace Tindall', gender: 'F', status: 'civilian', born: '2014', death: null, parent: 'Zara Phillips' },
-  { name: 'Lena Elizabeth Tindall', gender: 'F', status: 'civilian', born: '2018', death: null, parent: 'Zara Phillips' },
-  { name: 'Lucas Philip Tindall', gender: 'M', status: 'civilian', born: '2021', death: null, parent: 'Zara Phillips' },
-  { name: 'Sienna Mapeli Mozzi', gender: 'F', status: 'civilian', born: '2021', death: null, parent: 'Princess Beatrice of York' },
-  { name: 'August Brooksbank', gender: 'M', status: 'civilian', born: '2021', death: null, parent: 'Princess Eugenie of York' },
-  { name: 'Ernest Brooksbank', gender: 'M', status: 'civilian', born: '2023', death: null, parent: 'Princess Eugenie of York' }
+  { name: 'Albus Dumbledore', gender: 'M', status: 'wizard', born: '1881', death: '1997' },
+  { name: 'Minerva McGonagall', gender: 'F', status: 'witch', born: '1935', death: null, parent: 'Albus Dumbledore' },
+  { name: 'Severus Snape', gender: 'M', status: 'wizard', born: '1960', death: '1998', parent: 'Albus Dumbledore' },
+  { name: 'Rubeus Hagrid', gender: 'M', status: 'wizard', born: '1928', death: null, parent: 'Albus Dumbledore' },
+  { name: 'Sirius Black', gender: 'M', status: 'wizard', born: '1959', death: '1996', parent: 'Albus Dumbledore' },
+  { name: 'Remus Lupin', gender: 'M', status: 'wizard', born: '1960', death: '1998', parent: 'Albus Dumbledore' },
+  { name: 'Arthur Weasley', gender: 'M', status: 'wizard', born: '1950', death: null, parent: 'Albus Dumbledore' },
+  { name: 'Molly Weasley', gender: 'F', status: 'witch', born: '1950', death: null, parent: 'Arthur Weasley' },
+  { name: 'Bill Weasley', gender: 'M', status: 'wizard', born: '1970', death: null, parent: 'Ron Weasley' },
+  { name: 'Charlie Weasley', gender: 'M', status: 'wizard', born: '1972', death: null, parent: 'Arthur Weasley' },
+  { name: 'Percy Weasley', gender: 'M', status: 'wizard', born: '1976', death: null, parent: 'Arthur Weasley' },
+  { name: 'Fred Weasley', gender: 'M', status: 'wizard', born: '1978', death: '1998', parent: 'Arthur Weasley' },
+  { name: 'George Weasley', gender: 'M', status: 'wizard', born: '1978', death: null, parent: 'Arthur Weasley' },
+  { name: 'Ron Weasley', gender: 'M', status: 'wizard', born: '1980', death: null, parent: 'Arthur Weasley' },
+  { name: 'Ginny Weasley', gender: 'F', status: 'witch', born: '1981', death: null, parent: 'Arthur Weasley' },
+  { name: 'Harry Potter', gender: 'M', status: 'wizard', born: '1980', death: null, parent: 'Arthur Weasley' },
+  { name: 'Hermione Granger', gender: 'F', status: 'witch', born: '1979', death: null, parent: 'Harry Potter' },
+  { name: 'James Sirius Potter', gender: 'M', status: 'wizard', born: '2004', death: null, parent: 'Harry Potter' },
+  { name: 'Albus Severus Potter', gender: 'M', status: 'wizard', born: '2006', death: null, parent: 'Harry Potter' },
+  { name: 'Lily Luna Potter', gender: 'F', status: 'witch', born: '2008', death: null, parent: 'Harry Potter' }
 ];
 


### PR DESCRIPTION
## Summary
- fix call to nonexistent `bindObject` and use `bind(...).ofObject()`
- replace royal family data with Harry Potter characters
- keep one intentional hierarchy mistake in the data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685647ee2b848326b19ed7bd911e1913